### PR TITLE
Update external_task_link_procedures.rst

### DIFF
--- a/source/api/external_task_link_procedures.rst
+++ b/source/api/external_task_link_procedures.rst
@@ -100,7 +100,7 @@ updateExternalTaskLink
    -  **link_id** (integer, required)
    -  **title** (string, required)
    -  **url** (string, required)
-   -  **dependency** (string, required)
+   -  **dependency** (string, optional)
 
 -  Result on success: **true**
 -  Result on failure: **false**


### PR DESCRIPTION
dependency is not a required value in updateExternalTaskLink (Or is supposed to be, but is not working). I don't see why it would/could be required?