### PR TITLE
Update Debian instructions (Add v10, drop obsolete)

### DIFF
--- a/source/admin_guide/debian_installation.rst
+++ b/source/admin_guide/debian_installation.rst
@@ -1,6 +1,29 @@
 Installation on Debian
 ======================
 
+Debian 10 (Buster)
+------------------
+
+Install Apache and PHP:
+
+.. code:: bash
+
+    apt update
+    apt install -y apache2 libapache2-mod-php php-cli php-mbstring \
+        php-sqlite3 php-opcache php-json php-ldap php-gd php-xml  \
+        php-mysql php-pgsql
+
+    systemctl enable apache2
+
+Install Kanboard:
+
+.. code:: bash
+
+    version=1.2.13
+    wget https://github.com/kanboard/kanboard/archive/v$version.tar.gz
+    tar xzvf v$version.tar.gz -C /var/www/html/
+    chown -R www-data:www-data /var/www/html/kanboard-$version/data
+
 Debian 9 (Stretch)
 ------------------
 
@@ -13,7 +36,7 @@ Install Apache and PHP:
         php7.0-sqlite3 php7.0-opcache php7.0-json php7.0-mysql php7.0-pgsql \
         php7.0-ldap php7.0-gd php7.0-xml
 
-    systemctl enable apache2 postgresql
+    systemctl enable apache2
 
 Install Kanboard:
 
@@ -26,6 +49,8 @@ Install Kanboard:
 
 Debian 8 (Jessie)
 -----------------
+
+.. warning:: Debian 8 ships with PHP 5.  Since version 1.2.13, Kanboard requires at least PHP 7.2.
 
 Install Apache and PHP:
 
@@ -40,52 +65,6 @@ Install Kanboard:
 .. code:: bash
 
     cd /var/www/html
-
-    # Download the latest release from https://github.com/kanboard/kanboard/releases
-    wget https://github.com/kanboard/kanboard/archive/v<version>.zip
-
-    unzip kanboard-<version>.zip
-    chown -R www-data:www-data kanboard-<version>/data
-    rm kanboard-<version>.zip
-
-Debian 7 (Wheezy)
------------------
-
-Install Apache and PHP:
-
-.. code:: bash
-
-    apt-get update
-    apt-get install -y php5 php5-sqlite php5-gd unzip
-
-Install Kanboard:
-
-.. code:: bash
-
-    cd /var/www
-
-    # Download the latest release from https://github.com/kanboard/kanboard/releases
-    wget https://github.com/kanboard/kanboard/archive/v<version>.zip
-
-    unzip kanboard-<version>.zip
-    chown -R www-data:www-data kanboard-<version>/data
-    rm kanboard-<version>.zip
-
-Debian 6 (Squeeze)
-------------------
-
-Install Apache and PHP:
-
-.. code:: bash
-
-    apt-get update
-    apt-get install -y libapache2-mod-php5 php5-sqlite php5-gd unzip
-
-Install Kanboard:
-
-.. code:: bash
-
-    cd /var/www
 
     # Download the latest release from https://github.com/kanboard/kanboard/releases
     wget https://github.com/kanboard/kanboard/archive/v<version>.zip


### PR DESCRIPTION
Summary
- I added instructions for basic installation under Debian 10.  
- I also removed the instructions for the [obsolete/end-of-life versions](https://www.debian.org/releases/).
- Debian 8 (Jessie) is [still supported until June 2020](https://www.debian.org/releases/jessie/) but it ships with PHP 5, so I added a note to that effect in the Jessie section.
- Removed postgresql from the `systemctl enable` command since database config is discussed elsewhere in the docs and the user may be using MariaDB/MySQL.

These instructions were tested on a fresh installation of Debian 10.