### PR TITLE
Add missing backslash to fix syntax error

### DIFF
--- a/content/en/v1/admin/docker.md
+++ b/content/en/v1/admin/docker.md
@@ -132,7 +132,7 @@ Here is an example to enable the installation of plugins:
 
 ```bash
 docker run --rm \
-  --name=kanboard
+  --name=kanboard \
   -p 8080:80 \
   -e PLUGIN_INSTALLER=true \
   kanboard/kanboard:latest


### PR DESCRIPTION
Fix command by adding a backslash at the end of the --name option line to properly escape the newline character.