### PR TITLE
Fix minor grammatical error in config.md

### DIFF
--- a/content/en/v1/admin/config.md
+++ b/content/en/v1/admin/config.md
@@ -295,7 +295,7 @@ define('ENABLE_XFRAME', true);
 Logging
 -------
 
-By default, Kanboard do not log anything. If you want to enable the
+By default, Kanboard does not log anything. If you want to enable the
 logging, you have to set a log driver.
 
 ```php


### PR DESCRIPTION
This PR corrects a small grammatical error in the description of the Logging section for the Configuration File page in the documentation for improved readability.

- Fixed "By default, Kanboard do not log anything" → "By default, Kanboard does not log anything" in `config.md`.